### PR TITLE
Docs(README): Fixed a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ longer wavelengths.
 - red
 
 Similarly, amongst the longer wavelengths, we associate `yellow` with caution and
-yield. Less of an emergency but a still priority. `orange` we can see as a neutral
+yield. Less of an emergency but still a priority. `orange` we can see as a neutral
 between the two long wavelengths, which serves its purpose as a more neutral
 emergency but still unsettling as we can't tell which way it could go (lighter
 to yellow, or darker to red)


### PR DESCRIPTION
I fixed what seems to be a typo in the README.

I've noticed the NASA URL is no longer working and I didn't know what it had so decided to not change it to another link which might show a different thing.